### PR TITLE
Fix for SMODS 1222a+

### DIFF
--- a/lovely/void.toml
+++ b/lovely/void.toml
@@ -10,8 +10,8 @@ target = "game.lua"
 pattern = '''
 self.play = CardArea(
     0, 0,
-    CAI.play_W,CAI.play_H, 
-    {card_limit = 5, type = 'play'})
+    CAI.play_W,CAI.play_H,
+	{card_limit = 5, type = 'play', negative_info = 'playing_card'})
 '''
 position = "after"
 payload = '''

--- a/lovely/void.toml
+++ b/lovely/void.toml
@@ -11,7 +11,7 @@ pattern = '''
 self.play = CardArea(
     0, 0,
     CAI.play_W,CAI.play_H,
-	{card_limit = 5, type = 'play', negative_info = 'playing_card'})
+    {card_limit = 5, type = 'play', negative_info = 'playing_card'})
 '''
 position = "after"
 payload = '''


### PR DESCRIPTION
(Specifically [ea078b7c031045d3a4258a432211544846ee9c3c](https://github.com/Steamodded/smods/commit/ea078b7c031045d3a4258a432211544846ee9c3c))

Due to a change in the specific line targeted, this made the Void area not spawn and led to crashes. This changes the targeted line to match the change.